### PR TITLE
Update PR review workflow to use newer Anthropic models

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -29,6 +29,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           debug: true
-          bedrock_light_model: us.anthropic.claude-3-7-sonnet-20250219-v1:0
+          bedrock_light_model: us.anthropic.claude-sonnet-4-20250514-v1:0
           bedrock_heavy_model: us.anthropic.claude-opus-4-20250514-v1:0
           bedrock_timeout_ms: 120000

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -29,6 +29,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           debug: true
-          bedrock_light_model: anthropic.claude-3-haiku-20240307-v1:0
-          bedrock_heavy_model: anthropic.claude-3-haiku-20240307-v1:0
+          bedrock_light_model: us.anthropic.claude-3-7-sonnet-20250219-v1:0
+          bedrock_heavy_model: us.anthropic.claude-opus-4-20250514-v1:0
           bedrock_timeout_ms: 120000


### PR DESCRIPTION
## Summary
- Update bedrock_light_model to Claude 3.7 Sonnet (us.anthropic.claude-3-7-sonnet-20250219-v1:0)
- Update bedrock_heavy_model to Claude 4 Opus (us.anthropic.claude-opus-4-20250514-v1:0)

## Test plan
- [ ] Verify PR review workflow runs successfully with new models
- [ ] Check that both light and heavy models are accessible in us-east-1 region
- [ ] Confirm PR review comments are generated correctly

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- This is an auto-generated comment: release notes by AI reviewer -->
### Summary (generated)

## Release Notes

**Chore**: Upgraded AI models for PR review automation

- Updated PR review workflow to use newer Anthropic Claude 4 models
- Light reviews now use Claude Sonnet 4 (previously Claude 3 Haiku)
- Heavy reviews now use Claude Opus 4 (previously Claude 3 Haiku)
- Expect improved review quality and more sophisticated code analysis
- No changes to review triggering or timeout behavior
<!-- end of auto-generated comment: release notes by AI reviewer -->