### PR TITLE
Add magic byte validation for uploaded images to prevent MIME type spoofing

### DIFF
--- a/openfoodfacts-api.js
+++ b/openfoodfacts-api.js
@@ -119,6 +119,13 @@ class OpenFoodFactsAPI {
         let validSignature = false;
         for (const [format, signature] of Object.entries(signatures)) {
           if (signature.every((byte, index) => bytes[index] === byte)) {
+            // Additional check for WebP format - verify 'WEBP' identifier at offset 8
+            if (format === 'webp' && bytes.length >= 12) {
+              const webpIdentifier = [0x57, 0x45, 0x42, 0x50]; // 'WEBP'
+              if (!webpIdentifier.every((byte, index) => bytes[8 + index] === byte)) {
+                continue; // RIFF header found but not WebP, continue checking other formats
+              }
+            }
             validSignature = true;
             break;
           }

--- a/openfoodfacts-api.js
+++ b/openfoodfacts-api.js
@@ -85,7 +85,7 @@ class OpenFoodFactsAPI {
    * @param {File} file - File to validate
    * @private
    */
-  _validateImageFile(file) {
+  async _validateImageFile(file) {
     if (!file) {
       throw new Error('Image file is required');
     }
@@ -100,6 +100,40 @@ class OpenFoodFactsAPI {
       const maxSize = 10 * 1024 * 1024; // 10MB
       if (file.size > maxSize) {
         throw new Error('File size too large. Maximum size is 10MB.');
+      }
+    }
+    
+    // Additional magic byte validation for enhanced security
+    if (file.arrayBuffer && typeof file.arrayBuffer === 'function') {
+      try {
+        const buffer = await file.arrayBuffer();
+        const bytes = new Uint8Array(buffer);
+        
+        // Check magic bytes for known image formats
+        const signatures = {
+          jpeg: [0xFF, 0xD8, 0xFF],
+          png: [0x89, 0x50, 0x4E, 0x47],
+          webp: [0x52, 0x49, 0x46, 0x46] // RIFF header (WebP starts with RIFF)
+        };
+        
+        let validSignature = false;
+        for (const [format, signature] of Object.entries(signatures)) {
+          if (signature.every((byte, index) => bytes[index] === byte)) {
+            validSignature = true;
+            break;
+          }
+        }
+        
+        if (!validSignature) {
+          throw new Error('File content does not match allowed image formats');
+        }
+      } catch (error) {
+        // If magic byte validation fails, throw the error
+        if (error.message === 'File content does not match allowed image formats') {
+          throw error;
+        }
+        // For other errors (e.g., reading buffer), we'll log and continue
+        // This maintains compatibility with environments where arrayBuffer might not be available
       }
     }
   }
@@ -351,7 +385,7 @@ class OpenFoodFactsAPI {
     // Ensure secure connection before sending credentials
     this._validateSecureConnection();
     this._validateBarcode(barcode);
-    this._validateImageFile(image);
+    await this._validateImageFile(image);
     
     if (!type || !type.field || !type.languageCode) {
       throw new Error('Type with field and languageCode is required');

--- a/test-openfoodfacts-api.js
+++ b/test-openfoodfacts-api.js
@@ -761,7 +761,7 @@ describe('OpenFoodFactsAPI', () => {
       // Create mock files with valid magic bytes
       const validJpegBuffer = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]);
       const validPngBuffer = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A]);
-      const validWebpBuffer = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x28, 0x00]);
+      const validWebpBuffer = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50]);
       
       const validJpegFile = {
         type: 'image/jpeg',
@@ -796,6 +796,19 @@ describe('OpenFoodFactsAPI', () => {
       
       await assert.rejects(
         () => api._validateImageFile(invalidFile),
+        { message: 'File content does not match allowed image formats' }
+      );
+      
+      // Test RIFF header without WEBP identifier (should be rejected)
+      const riffOnlyBuffer = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x41, 0x56, 0x49, 0x20]); // RIFF + AVI
+      const riffOnlyFile = {
+        type: 'image/webp',
+        size: 1024,
+        arrayBuffer: async () => riffOnlyBuffer.buffer
+      };
+      
+      await assert.rejects(
+        () => api._validateImageFile(riffOnlyFile),
         { message: 'File content does not match allowed image formats' }
       );
       

--- a/test-openfoodfacts-api.js
+++ b/test-openfoodfacts-api.js
@@ -713,7 +713,7 @@ describe('OpenFoodFactsAPI', () => {
       );
     });
 
-    test('should validate image files correctly', () => {
+    test('should validate image files correctly', async () => {
       api = new OpenFoodFactsAPI();
       
       // Test valid image files
@@ -721,38 +721,87 @@ describe('OpenFoodFactsAPI', () => {
       const validPng = { type: 'image/png', size: 2048 };
       const validWebp = { type: 'image/webp', size: 4096 };
       
-      assert.doesNotThrow(() => api._validateImageFile(validJpeg));
-      assert.doesNotThrow(() => api._validateImageFile(validPng));
-      assert.doesNotThrow(() => api._validateImageFile(validWebp));
+      await assert.doesNotReject(() => api._validateImageFile(validJpeg));
+      await assert.doesNotReject(() => api._validateImageFile(validPng));
+      await assert.doesNotReject(() => api._validateImageFile(validWebp));
       
       // Test null/undefined file
-      assert.throws(
+      await assert.rejects(
         () => api._validateImageFile(null),
         { message: 'Image file is required' }
       );
       
-      assert.throws(
+      await assert.rejects(
         () => api._validateImageFile(undefined),
         { message: 'Image file is required' }
       );
       
       // Test invalid file type
       const invalidFile = { type: 'text/plain', size: 1024 };
-      assert.throws(
+      await assert.rejects(
         () => api._validateImageFile(invalidFile),
         { message: 'Invalid file type. Only JPEG, PNG, and WebP images are allowed.' }
       );
       
       // Test oversized file
       const largeFile = { type: 'image/jpeg', size: 11 * 1024 * 1024 };
-      assert.throws(
+      await assert.rejects(
         () => api._validateImageFile(largeFile),
         { message: 'File size too large. Maximum size is 10MB.' }
       );
       
       // Test mock objects (no type/size properties) - should not throw
       const mockFile = {};
-      assert.doesNotThrow(() => api._validateImageFile(mockFile));
+      await assert.doesNotReject(() => api._validateImageFile(mockFile));
+    });
+
+    test('should validate image files with magic bytes', async () => {
+      api = new OpenFoodFactsAPI();
+      
+      // Create mock files with valid magic bytes
+      const validJpegBuffer = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]);
+      const validPngBuffer = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A]);
+      const validWebpBuffer = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x28, 0x00]);
+      
+      const validJpegFile = {
+        type: 'image/jpeg',
+        size: 1024,
+        arrayBuffer: async () => validJpegBuffer.buffer
+      };
+      
+      const validPngFile = {
+        type: 'image/png',
+        size: 1024,
+        arrayBuffer: async () => validPngBuffer.buffer
+      };
+      
+      const validWebpFile = {
+        type: 'image/webp',
+        size: 1024,
+        arrayBuffer: async () => validWebpBuffer.buffer
+      };
+      
+      // Test valid magic bytes
+      await assert.doesNotReject(() => api._validateImageFile(validJpegFile));
+      await assert.doesNotReject(() => api._validateImageFile(validPngFile));
+      await assert.doesNotReject(() => api._validateImageFile(validWebpFile));
+      
+      // Test invalid magic bytes
+      const invalidBuffer = new Uint8Array([0x50, 0x4B, 0x03, 0x04]); // ZIP header
+      const invalidFile = {
+        type: 'image/jpeg',
+        size: 1024,
+        arrayBuffer: async () => invalidBuffer.buffer
+      };
+      
+      await assert.rejects(
+        () => api._validateImageFile(invalidFile),
+        { message: 'File content does not match allowed image formats' }
+      );
+      
+      // Test file without arrayBuffer method (should not throw for backwards compatibility)
+      const fileWithoutArrayBuffer = { type: 'image/jpeg', size: 1024 };
+      await assert.doesNotReject(() => api._validateImageFile(fileWithoutArrayBuffer));
     });
 
     test('should sanitize search input correctly', () => {


### PR DESCRIPTION
## Summary
- Enhanced file validation by adding magic byte checking for uploaded images
- Prevents malicious files from bypassing client-side validation by spoofing MIME types
- Maintains backward compatibility with environments lacking arrayBuffer support

## Test plan
- [x] All existing tests pass
- [x] New tests added for magic byte validation scenarios
- [x] Verified async validation works correctly with uploadPhoto method
- [x] Confirmed backwards compatibility with mock files

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by AI reviewer -->
### Summary (generated)

## Release Notes

### Security Enhancement
- **New Feature**: Added magic byte validation for image uploads to prevent MIME type spoofing attacks
- **New Feature**: Enhanced security by verifying actual file content matches declared file type (JPEG, PNG, WebP)

### Technical Updates
- **Refactor**: Image validation now uses asynchronous processing for improved file header checking
- **Test**: Added comprehensive test coverage for new image validation scenarios

**Note**: This security enhancement provides additional protection against malicious file uploads while maintaining compatibility with existing functionality.
<!-- end of auto-generated comment: release notes by AI reviewer -->